### PR TITLE
Add safely rollback when ebpf programming failed mechanism by segment lock

### DIFF
--- a/include/grpc_client.h
+++ b/include/grpc_client.h
@@ -21,6 +21,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 #include "arionmaster.grpc.pb.h"
+#include "segment_lock.h"
 #include <sqlite_orm.h>
 #include <concurrency/ConcurrentHashMap.h>
 #include "bpf.h"
@@ -58,6 +59,9 @@ private:
 
     // key std::string is '<vni>-<vpc_ip>', value is inserted version of this neighbor
     folly::ConcurrentHashMap<std::string, int> neighbor_task_map;
+
+    // segment lock for neighbor key version control
+    SegmentLock segment_lock;
 };
 
 struct AsyncClientCall {

--- a/include/segment_lock.h
+++ b/include/segment_lock.h
@@ -1,0 +1,34 @@
+// MIT License
+// Copyright(c) 2022 Futurewei Cloud
+//
+//     Permission is hereby granted,
+//     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+//     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+//     to whom the Software is furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include <string>
+#include <SharedMutex.h>  /* folly::SharedMutex */
+
+const int LOCK_ARRAY_SIZE = 1024;
+
+class SegmentLock {
+public:
+    void lock(const std::string& key);
+
+    void unlock(const std::string& key);
+
+    SegmentLock() = default;
+
+    ~SegmentLock() = default;
+
+private:
+    folly::SharedMutex _segment_mutex[LOCK_ARRAY_SIZE];
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../build/bin)
 
 set(SOURCES
     ./util/dispatch_queue.cpp
+    ./util/segment_lock.cpp
     ./comm/grpc_client.cpp
     )
 

--- a/src/util/segment_lock.cpp
+++ b/src/util/segment_lock.cpp
@@ -1,0 +1,29 @@
+// MIT License
+// Copyright(c) 2022 Futurewei Cloud
+//
+//     Permission is hereby granted,
+//     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+//     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+//     to whom the Software is furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include "segment_lock.h"
+
+void SegmentLock::lock(const std::string& key) {
+    std::hash<std::string> hash_fn;
+    int index = hash_fn(key) % LOCK_ARRAY_SIZE;
+
+    _segment_mutex[index].lock();
+}
+
+void SegmentLock::unlock(const std::string& key) {
+    std::hash<std::string> hash_fn;
+    int index = hash_fn(key) % LOCK_ARRAY_SIZE;
+
+    _segment_mutex[index].unlock();
+}


### PR DESCRIPTION
- Segment lock (not the concurrent hashmap hashing segment)
- Behavior and performance
  - Concurrent hashmap still supports different keys inserting at the same time
  - Lock segment is not the hashmap (collision resolver) segment
  - Concurrency is lowered to segment size and distribution aspect
  - Neighbor hashing segment locking will make sure
    - Same neighbor key’s different versions is always thread-safe
    - But multiple neighbor keys that hashed to the same segment is also locked
    - Different neighbor keys that hashed to different segments continue to be concurrent